### PR TITLE
Playlist pipeline

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,11 @@ github_username:  chirpradio
 
 # Build settings
 remote_theme: just-the-docs/just-the-docs
+mermaid:
+  # Version of mermaid library
+  # Pick an available version from https://cdn.jsdelivr.net/npm/mermaid/
+  version: "10.8.0"
+
 plugins:
   - jekyll-feed
 logo: "/assets/images/CHIRP_Logo_FM URL_horizontal_600.png"

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,4 @@
+<link
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+  rel="stylesheet"
+/>

--- a/project_pages/nextup.md
+++ b/project_pages/nextup.md
@@ -9,3 +9,70 @@ parent: Active Projects
 # NextUp
 
 A recording from our 2024 meeting "NextUp Demo and Q&A" can be found in Slack [here](https://chirpdev.slack.com/archives/C01GSPCEDMK/p1706757506383289).
+
+## Playlist pipeline [WIP]
+NextUp uses a set of microservices that run as [Cloud Functions](https://cloud.google.com/functions/#documentation) and communicate through [Cloud Pub/Sub](https://cloud.google.com/pubsub/#documentation) messages to enrich freeform tracks with images and let the website and mobile apps know what's playing.
+
+```mermaid
+flowchart TB
+    NextUp[fa:fa-record-vinyl NextUp] 
+    NextUp --> |Pub/Sub<br>playlist-event| process(fa:fa-code processPlaylistTrack)    
+    subgraph storage
+        update(fa:fa-code updatePlaylistStorage)
+        cloud(fa:fa-bucket playlist.json)
+        update --> |builds & saves| cloud
+    end
+    process --> |Pub/Sub: playlist-track-processed | storage    
+    storage -->|Pub/Sub: playlist-storage-updated| notify(fa:fa-code notifyLiveSite)
+    notify --> |GET| website(fa:fa-globe chirpradio.org)
+    website --> |GET| cloud
+```
+
+### Topic: "playlist-event"
+The NextUp API added a track to the playlist, updated a track on the playlist, or deleted a track from the playlist
+
+#### Message
+
+| Field Name   | Type            | Description |
+|:-------------|:----------------|:------------|
+| action       | String          | "added", "updated", or "deleted"  |
+| track        | [PlaylistEvent](https://github.com/chirpradio/nextup/blob/develop/app/models/playlistevent.model.js)   | The plain JSON output of the PlaylistEvent entity from the Datastore. Keys *have not* yet been replaced with the related entities they reference (e.g., the `artist` value is a key). |
+
+#### Subscriber(s)
+- processPlaylistTrack
+  - checks LastFM for images it can add to the PlaylistEvent entity
+  - retrieves the details of related objects from the NextUp database for the benefit of later steps in the pipeline
+    - album
+    - artist
+    - track
+    - selector (i.e., the DJ)
+  - publishes a message to the "playlist-track-processed" topic
+
+### Topic: "playlist-track-processed"
+The track data has been enriched and can be used by later steps without querying the Datastore
+
+#### Message
+
+| Field Name   | Type            | Description |
+|:-------------|:----------------|:------------|
+| action       | String          | "added", "updated", or "deleted"  |
+| track        | [PlaylistEvent](https://github.com/chirpradio/nextup/blob/develop/app/models/playlistevent.model.js)   | The plain JSON output of the PlaylistEvent entity from the Datastore. Keys *have* been replaced with the entities they reference (e.g., the `artist` value is an object with details on the artist).  |
+
+#### Subscriber(s)
+- updatePlaylistStorage 
+  - builds and saves the public JSON feed of recently played tracks to a Cloud Storage bucket
+  - publishes a message to the "playlist-storage-updated" topic
+
+### Topic: "playlist-storage-updated"
+The JSON feed that lists the track playing now and the five most recently played tracks before it has been updated.
+
+#### Message
+_a passthrough of the "playlist-track-processed" message_
+
+| Field Name   | Type            | Description |
+|:-------------|:----------------|:------------|
+| action       | String          | "added", "updated", or "deleted"  |
+| track        | [PlaylistEvent](https://github.com/chirpradio/nextup/blob/develop/app/models/playlistevent.model.js)   | The plain JSON output of the PlaylistEvent entity from the Datastore. Keys *have* been replaced with the entities they reference (e.g., the `artist` value is an object with details on the artist).  |
+
+#### Subscriber(s)
+- notifyLiveSite: calls endpoints at chirpradio.org that prompt it to retrieve the latest version of playlist.json from the Cloud Storage bucket


### PR DESCRIPTION
- [Enable Just the Docs support of Mermaid diagrams](https://just-the-docs.github.io/just-the-docs/docs/ui-components/code/#mermaid-diagram-code-blocks)
  - Also include Font Awesome CSS for use in Mermaid diagrams
- Add diagram and details on the messages and microservices that will handle updates to the playlist made from NextUp

Once the functions are merged to the main branch of the cloud-functions repo I'll link them in each Subscriber(s) section.